### PR TITLE
Integration card rename and deprecate existing one

### DIFF
--- a/packages/engine-frontend/DeprecatedOpenIntConnect.tsx
+++ b/packages/engine-frontend/DeprecatedOpenIntConnect.tsx
@@ -22,6 +22,7 @@ import type {SchemaFormElement, UIProps, UIPropsNoChildren} from '@openint/ui'
 import {
   Button,
   ConnectorConfigCard,
+  DeprecatedIntegrationCard,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -36,7 +37,6 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-  IntegrationCard,
   ResourceCard,
   SchemaForm,
   useToast,
@@ -364,7 +364,7 @@ export function _OpenIntConnect({
         ))}
       {!debugConnectorConfigs &&
         configuredIntegrations.map((int) => (
-          <IntegrationCard
+          <DeprecatedIntegrationCard
             {...uiProps}
             key={int.id}
             integration={{
@@ -382,7 +382,7 @@ export function _OpenIntConnect({
                 onEvent?.({type: e.type, ccfgId: int.connector_config_id})
               }}
             />
-          </IntegrationCard>
+          </DeprecatedIntegrationCard>
         ))}
     </div>
   )

--- a/packages/engine-frontend/components/IntegrationSearch.tsx
+++ b/packages/engine-frontend/components/IntegrationSearch.tsx
@@ -4,7 +4,7 @@ import {Loader, Search} from 'lucide-react'
 import {useState} from 'react'
 import {Input, parseCategory} from '@openint/ui'
 import {CheckboxFilter} from '@openint/ui/components/CheckboxFilter'
-import {ConnectionCard} from '@openint/ui/domain-components/ConnectionCard'
+import {IntegrationCard} from '@openint/ui/domain-components/IntegrationCard'
 import type {ConnectorConfig} from '../hocs/WithConnectConfig'
 import type {ConnectEventType} from '../hocs/WithConnectorConnect'
 import {WithConnectorConnect} from '../hocs/WithConnectorConnect'
@@ -111,7 +111,7 @@ export function IntegrationSearch({
                           })
                         }}>
                         {({openConnect}) => (
-                          <ConnectionCard
+                          <IntegrationCard
                             onClick={openConnect}
                             logo={int.ccfg.connector.logoUrl ?? ''}
                             name={int.name}

--- a/packages/ui/domain-components/DeprecatedIntegrationCard.tsx
+++ b/packages/ui/domain-components/DeprecatedIntegrationCard.tsx
@@ -27,7 +27,7 @@ interface UIProps extends UIPropsNoChildren {
 
 type Integration = RouterOutput['listConfiguredIntegrations']['items'][number]
 
-export const IntegrationCard = ({
+export const DeprecatedIntegrationCard = ({
   integration: int,
   className,
   children,

--- a/packages/ui/domain-components/IntegrationCard.tsx
+++ b/packages/ui/domain-components/IntegrationCard.tsx
@@ -2,7 +2,7 @@ import {Plus} from 'lucide-react'
 import {useState} from 'react'
 import {Card, CardContent} from '../shadcn'
 
-export function ConnectionCard({
+export function IntegrationCard({
   logo,
   name,
   onClick,

--- a/packages/ui/domain-components/index.ts
+++ b/packages/ui/domain-components/index.ts
@@ -1,5 +1,5 @@
 // codegen:start {preset: barrel, include: "./{*.{ts,tsx},*/index.{ts,tsx}}", exclude: "./**/*.{d,spec,test,fixture,gen,node}.{ts,tsx}"}
 export * from './ConnectorCard'
-export * from './IntegrationCard'
+export * from './DeprecatedIntegrationCard'
 export * from './ResourceCard'
 // codegen:end

--- a/packages/ui/stories/IntegrationCard.stories.tsx
+++ b/packages/ui/stories/IntegrationCard.stories.tsx
@@ -1,11 +1,11 @@
 import {fn} from '@storybook/test'
 import logoGreenhouse from '../../../apps/web/public/_assets/logo-greenhouse.svg'
-import {ConnectionCard} from '../domain-components/ConnectionCard'
+import {IntegrationCard} from '../domain-components/IntegrationCard'
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 export default {
-  title: 'Example/ConnectionCard',
-  component: ConnectionCard,
+  title: 'Example/IntegrationCard',
+  component: IntegrationCard,
   parameters: {
     // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
     layout: 'centered',


### PR DESCRIPTION
- Rename previous and update references.
- Update new card name to match the model expected name.